### PR TITLE
Install model.config only for Gazebo supported models

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors: Silvio Traversaro
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
-cmake_minimum_required(VERSION 2.8.9)
+cmake_minimum_required(VERSION 3.5)
 
 project(icub-models)
 
@@ -20,13 +20,30 @@ endmacro()
 # Copy the iCub folder in the build tree
 file(COPY ${CMAKE_SOURCE_DIR}/iCub DESTINATION ${CMAKE_BINARY_DIR})
 
-# Generate and move in the build tree the model.config for each robot
+# Add the model.config just for a limited number of models that are known
+# to work in Gazebo, unless the ICUB_MODELS_INSTALL_ALL_GAZEBO_MODELS option
+# is enabled
+option(ICUB_MODELS_INSTALL_ALL_GAZEBO_MODELS OFF)
+
+# Note: all the models run in Gazebo, but this two are the only one that
+# run with the default physics settings of Gazebo, see issue
+# https://github.com/robotology/icub-model-generator/issues/52 for more info
+set(GAZEBO_SUPPORTED_MODELS "")
+list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV2_5")
+list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV2_5_plus")
+
 SUBDIRLIST(ROBOTS_NAMES ${CMAKE_BINARY_DIR}/iCub/robots)
 foreach (ROBOT_DIRNAME ${ROBOTS_NAMES})
   set(ROBOT_NAME ${ROBOT_DIRNAME})
-  configure_file(${CMAKE_SOURCE_DIR}/model.config.in
-                 ${CMAKE_BINARY_DIR}/iCub/robots/${ROBOT_NAME}/model.config
-                 @ONLY)
+  set(ROBOT_MODEL_CONFIG_FILE "${CMAKE_BINARY_DIR}/iCub/robots/${ROBOT_NAME}/model.config")
+  if(ROBOT_NAME IN_LIST GAZEBO_SUPPORTED_MODELS OR ICUB_MODELS_INSTALL_ALL_GAZEBO_MODELS)
+    configure_file(${CMAKE_SOURCE_DIR}/model.config.in
+                   ${ROBOT_MODEL_CONFIG_FILE}
+                   @ONLY)
+  else()
+    # Cleanup is before ICUB_MODELS_INSTALL_ALL_GAZEBO_MODELS was set to ON
+    file(REMOVE ${ROBOT_MODEL_CONFIG_FILE})
+  endif()
 endforeach()
 
 # Install the whole iCub directory

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ In order to use these models in Gazebo, set up the simulation environment follow
 ```
 export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH}:<prefix>/share/iCub/robots:<prefix>/share
 ```
+Note that only the models that are known to work fine with the default physics engine settings of Gazebo (`iCubGazeboV2_5` and `iCubGazeboV2_5_plus`)
+are installed. If you want to make available in Gazebo all the models, enable the `ICUB_MODELS_INSTALL_ALL_GAZEBO_MODELS` CMake option.
 Note that it is still a **Work In Progress**. See the issue https://github.com/robotology-playground/icub-models/issues/7
 
 ## Change the orientation of the root frame


### PR DESCRIPTION
If the user want to install model.config for all the files, the
`ICUB_MODELS_INSTALL_ALL_GAZEBO_MODELS` CMake option is still available.

Fix https://github.com/robotology/icub-models/issues/11 