### PR TITLE
[iCubGazeboV2_5] enable all_joints controlboardwrapper and ROS joint states

### DIFF
--- a/iCub/conf/gazebo_icub_wholebody_ros.ini
+++ b/iCub/conf/gazebo_icub_wholebody_ros.ini
@@ -1,0 +1,22 @@
+[include "gazebo_icub_robotname.ini"]
+
+# Verbose output (on if present, off if commented out)
+#verbose
+
+[WRAPPER]
+device controlboardwrapper2
+period 10
+name /${gazeboYarpPluginsRobotName}/all_joints
+joints 32
+networks (head torso left_arm_no_hand right_arm_no_hand left_leg right_leg)
+head               0 2  0 2
+torso              3 5  0 2
+left_arm_no_hand   6 12 0 6
+right_arm_no_hand 13 19 0 6
+left_leg          20 25 0 5
+right_leg         26 31 0 5
+
+[ROS]
+useROS true
+ROS_topicName  /${gazeboYarpPluginsRobotName}/joint_states
+ROS_nodeName   /${gazeboYarpPluginsRobotName}/joint_state_publisher

--- a/iCub/robots/iCubGazeboV2_5/model.urdf
+++ b/iCub/robots/iCubGazeboV2_5/model.urdf
@@ -2281,6 +2281,9 @@
 <plugin name="controlboard_left_leg" filename="libgazebo_yarp_controlboard.so">
   <yarpConfigurationFile>model://iCub/conf/gazebo_icub_left_leg.ini</yarpConfigurationFile>
 </plugin>
+<plugin name='controlboard_wholebody_ros' filename='libgazebo_yarp_controlboard.so'>
+  <yarpConfigurationFile>model://iCub/conf/gazebo_icub_wholebody_ros.ini</yarpConfigurationFile>
+</plugin>
 <plugin name="apply_external_wrench" filename="libgazebo_yarp_externalwrench.so">
   <robotNamefromConfigFile>model://iCub/conf/gazebo_icub_robotname.ini</robotNamefromConfigFile>
 </plugin>


### PR DESCRIPTION
This PR allows to,
- access the joints information through a single device
- enable ROS related parameters to publish joint states for ROS-based processing

NOTE: The changes are suggested only for the iCubGazeboV2_5 model.

P.S. Thanks to Yeshasvi for this feature!