### PR TITLE
Add a workaround for https://github.com/osrf/gazebo/issues/2728

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,14 @@ file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/ros DESTINATION ${CMAKE_CURRENT_BINARY_DIR
 # is enabled
 option(ICUB_MODELS_INSTALL_ALL_GAZEBO_MODELS OFF)
 
+# Workaround for https://github.com/robotology/icub-models/issues/39 and 
+# https://github.com/osrf/gazebo/issues/2728
+set(ICUB_MODELS_SDF_VERSION "1.5")
+find_package(GAZEBO QUIET)
+if(GAZEBO_FOUND AND GAZEBO_VERSION VERSION_GREATER_EQUAL 11.0)
+  set(ICUB_MODELS_SDF_VERSION "1.7")
+endif()
+
 # Note: all the models run in Gazebo, but this two are the only one that
 # run with the default physics settings of Gazebo, see issue
 # https://github.com/robotology/icub-model-generator/issues/52 for more info

--- a/feet_fixed_model.sdf.in
+++ b/feet_fixed_model.sdf.in
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<sdf version='1.5'>
+<sdf version='@ICUB_MODELS_SDF_VERSION@'>
   <model name="iCub_feet_fixed">
     <include>
       <uri>model://@ROBOT_NAME@</uri>

--- a/fixed_model.sdf.in
+++ b/fixed_model.sdf.in
@@ -1,5 +1,5 @@
 <?xml version='1.0'?>
-<sdf version='1.5'>
+<sdf version='@ICUB_MODELS_SDF_VERSION@'>
   <model name="iCub_fixed">
     <include>
       <uri>model://@ROBOT_NAME@</uri>


### PR DESCRIPTION
Fix https://github.com/robotology/icub-models/issues/39 by generating SDF with 1.7 version if Gazebo >= 11 is found. The workaround can be removed once  https://github.com/osrf/gazebo/issues/2728 is fixed. 