### PR TITLE
Switch controlboard plugins to set velocityControlImplementationType to integrator_and_position_pid

### DIFF
--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_head.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_head.ini
@@ -51,6 +51,7 @@ stictionUp    0.0   0.0   0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 0.01  0.01  0.01

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_left_hand_finger.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_left_hand_finger.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 5.235

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_left_hand_index.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_left_hand_index.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_left_hand_middle.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_left_hand_middle.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_left_hand_pinky.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_left_hand_pinky.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 8.726 8.726 8.726

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_left_hand_thumb.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_left_hand_thumb.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 5.236

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_right_hand_finger.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_right_hand_finger.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 5.236

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_right_hand_index.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_right_hand_index.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_right_hand_middle.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_right_hand_middle.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_right_hand_pinky.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_right_hand_pinky.ini
@@ -46,6 +46,7 @@ stictionUp    0.0   0.0   0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 8.726 8.726 8.726

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_right_hand_thumb.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_right_hand_thumb.ini
@@ -45,6 +45,7 @@ stictionUp    0.0   0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 5.236

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_right_leg.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_right_leg.ini
@@ -48,6 +48,7 @@ stictionUp    0.0    0.0    0.0    0.0    0.0    0.0
 stictionDwn   0.0    0.0    0.0    0.0    0.0    0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726 8.726 8.726 8.726

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_torso.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_torso.ini
@@ -48,6 +48,7 @@ stictionUp    0.0   0.0   0.0
 stictionDwn   0.0   0.0   0.0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType integrator_and_position_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            8.726 8.726 8.726


### PR DESCRIPTION
This change is ignored for versions of gazebo-yarp-plugins <= 3.5.0, but for version of gazebo-yarp-plugins > 3.5.0 it aligns the behavior of the VOCAB_CM_VELOCITY control mode with the one of the real iCub robot.

This PR only handles the manually managed configuration files, while the one automatically generated will be handled by https://github.com/robotology/icub-model-generator/pull/138 .


Related issues:
 * robotology/gazebo-yarp-plugins#514
 * robotology/gazebo-yarp-plugins#240