### PR TITLE
Fixed multiple generation of fixed models and add uninstall target.

### DIFF
--- a/AddUninstallTarget.cmake
+++ b/AddUninstallTarget.cmake
@@ -1,0 +1,70 @@
+#.rst:
+# AddUninstallTarget
+# ------------------
+#
+# Add the "uninstall" target for your project::
+#
+#   include(AddUninstallTarget)
+#
+#
+# will create a file cmake_uninstall.cmake in the build directory and add a
+# custom target uninstall that will remove the files installed by your package
+# (using install_manifest.txt)
+
+#=============================================================================
+# Copyright 2008-2013 Kitware, Inc.
+# Copyright 2013 Istituto Italiano di Tecnologia (IIT)
+#   Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+
+if(DEFINED __ADD_UNINSTALL_TARGET_INCLUDED)
+  return()
+endif()
+set(__ADD_UNINSTALL_TARGET_INCLUDED TRUE)
+
+
+set(_filename ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+
+file(WRITE ${_filename}
+"if(NOT EXISTS \"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\")
+    message(WARNING \"Cannot find install manifest: \\\"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\\\"\")
+    return()
+endif()
+
+file(READ \"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\" files)
+string(STRIP \"\${files}\" files)
+string(REGEX REPLACE \"\\n\" \";\" files \"\${files}\")
+list(REVERSE files)
+foreach(file \${files})
+    message(STATUS \"Uninstalling: \$ENV{DESTDIR}\${file}\")
+    if(EXISTS \"\$ENV{DESTDIR}\${file}\")
+        execute_process(
+            COMMAND \${CMAKE_COMMAND} -E remove \"\$ENV{DESTDIR}\${file}\"
+            OUTPUT_VARIABLE rm_out
+            RESULT_VARIABLE rm_retval)
+        if(NOT \"\${rm_retval}\" EQUAL 0)
+            message(FATAL_ERROR \"Problem when removing \\\"\$ENV{DESTDIR}\${file}\\\"\")
+        endif()
+    else()
+        message(STATUS \"File \\\"\$ENV{DESTDIR}\${file}\\\" does not exist.\")
+    endif()
+endforeach(file)
+")
+
+if("${CMAKE_GENERATOR}" MATCHES "^(Visual Studio|Xcode)")
+    set(_uninstall "UNINSTALL")
+else()
+    set(_uninstall "uninstall")
+endif()
+add_custom_target(${_uninstall} COMMAND "${CMAKE_COMMAND}" -P "${_filename}")
+set_property(TARGET ${_uninstall} PROPERTY FOLDER "CMakePredefinedTargets")

--- a/AddUninstallTarget.cmake
+++ b/AddUninstallTarget.cmake
@@ -7,9 +7,20 @@
 #   include(AddUninstallTarget)
 #
 #
-# will create a file cmake_uninstall.cmake in the build directory and add a
-# custom target uninstall that will remove the files installed by your package
-# (using install_manifest.txt)
+# will create a file ``cmake_uninstall.cmake`` in the build directory and add a
+# custom target ``uninstall`` (or ``UNINSTALL`` on Visual Studio and Xcode) that
+# will remove the files installed by your package (using
+# ``install_manifest.txt``).
+# See also
+# https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake
+#
+# The :module:`AddUninstallTarget` module must be included in your main
+# ``CMakeLists.txt``. If included in a subdirectory it does nothing.
+# This allows you to use it safely in your main ``CMakeLists.txt`` and include
+# your project using ``add_subdirectory`` (for example when using it with
+# :cmake:module:`FetchContent`).
+#
+# If the ``uninstall`` target already exists, the module does nothing.
 
 #=============================================================================
 # Copyright 2008-2013 Kitware, Inc.
@@ -27,18 +38,31 @@
 #  License text for the above reference.)
 
 
-if(DEFINED __ADD_UNINSTALL_TARGET_INCLUDED)
+# AddUninstallTarget works only when included in the main CMakeLists.txt
+if(NOT "${CMAKE_CURRENT_BINARY_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
   return()
 endif()
-set(__ADD_UNINSTALL_TARGET_INCLUDED TRUE)
+
+# The name of the target is uppercase in MSVC and Xcode (for coherence with the
+# other standard targets)
+if("${CMAKE_GENERATOR}" MATCHES "^(Visual Studio|Xcode)")
+  set(_uninstall "UNINSTALL")
+else()
+  set(_uninstall "uninstall")
+endif()
+
+# If target is already defined don't do anything
+if(TARGET ${_uninstall})
+  return()
+endif()
 
 
-set(_filename ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+set(_filename cmake_uninstall.cmake)
 
-file(WRITE ${_filename}
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${_filename}"
 "if(NOT EXISTS \"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\")
-    message(WARNING \"Cannot find install manifest: \\\"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\\\"\")
-    return()
+  message(WARNING \"Cannot find install manifest: \\\"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\\\"\")
+  return()
 endif()
 
 file(READ \"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\" files)
@@ -46,25 +70,33 @@ string(STRIP \"\${files}\" files)
 string(REGEX REPLACE \"\\n\" \";\" files \"\${files}\")
 list(REVERSE files)
 foreach(file \${files})
+  if(IS_SYMLINK \"\$ENV{DESTDIR}\${file}\" OR EXISTS \"\$ENV{DESTDIR}\${file}\")
     message(STATUS \"Uninstalling: \$ENV{DESTDIR}\${file}\")
-    if(EXISTS \"\$ENV{DESTDIR}\${file}\")
-        execute_process(
-            COMMAND \${CMAKE_COMMAND} -E remove \"\$ENV{DESTDIR}\${file}\"
-            OUTPUT_VARIABLE rm_out
-            RESULT_VARIABLE rm_retval)
-        if(NOT \"\${rm_retval}\" EQUAL 0)
-            message(FATAL_ERROR \"Problem when removing \\\"\$ENV{DESTDIR}\${file}\\\"\")
-        endif()
-    else()
-        message(STATUS \"File \\\"\$ENV{DESTDIR}\${file}\\\" does not exist.\")
+    execute_process(
+      COMMAND \${CMAKE_COMMAND} -E remove \"\$ENV{DESTDIR}\${file}\"
+      OUTPUT_VARIABLE rm_out
+      RESULT_VARIABLE rm_retval)
+    if(NOT \"\${rm_retval}\" EQUAL 0)
+      message(FATAL_ERROR \"Problem when removing \\\"\$ENV{DESTDIR}\${file}\\\"\")
     endif()
+  else()
+    message(STATUS \"Not-found: \$ENV{DESTDIR}\${file}\")
+  endif()
 endforeach(file)
 ")
 
-if("${CMAKE_GENERATOR}" MATCHES "^(Visual Studio|Xcode)")
-    set(_uninstall "UNINSTALL")
+set(_desc "Uninstall the project...")
+if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+  set(_comment COMMAND \$\(CMAKE_COMMAND\) -E cmake_echo_color --switch=$\(COLOR\) --cyan "${_desc}")
 else()
-    set(_uninstall "uninstall")
+  set(_comment COMMENT "${_desc}")
 endif()
-add_custom_target(${_uninstall} COMMAND "${CMAKE_COMMAND}" -P "${_filename}")
+add_custom_target(${_uninstall}
+                  ${_comment}
+                  COMMAND ${CMAKE_COMMAND} -P ${_filename}
+                  USES_TERMINAL
+                  BYPRODUCTS uninstall_byproduct
+                  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+set_property(SOURCE uninstall_byproduct PROPERTY SYMBOLIC 1)
+
 set_property(TARGET ${_uninstall} PROPERTY FOLDER "CMakePredefinedTargets")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ set(GAZEBO_SUPPORTED_MODELS "")
 list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV2_5")
 list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV2_5_plus")
 
-SUBDIRLIST(ROBOTS_NAMES ${CMAKE_CURRENT_BINARY_DIR}/iCub/robots)
+SUBDIRLIST(ROBOTS_NAMES ${CMAKE_CURRENT_SOURCE_DIR}/iCub/robots)
 foreach(ROBOT_DIRNAME ${ROBOTS_NAMES})
   set(ROBOT_NAME ${ROBOT_DIRNAME})
   set(ROBOT_MODEL_CONFIG_FILE "${CMAKE_CURRENT_BINARY_DIR}/iCub/robots/${ROBOT_NAME}/model.config")
@@ -115,4 +115,6 @@ endforeach()
 
 # Install the whole iCub directory
 install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/iCub DESTINATION share)
+
+include(AddUninstallTarget.cmake)
 


### PR DESCRIPTION
While trying to install the iCub3 model I realized that fixed models were created multiple times 
![image](https://user-images.githubusercontent.com/18591940/96335293-015e2880-1078-11eb-90ef-94cf7812072c.png)

In addition, there was no ``uninstall`` target to remove them.

Apparently, due to caching, this fix works only after deleting the build folder of ``icub-models``

cc @traversaro 