### PR TITLE
Fix the child link in the "fixed_base" joint for fixed_model.sdf.in

### DIFF
--- a/fixed_model.sdf.in
+++ b/fixed_model.sdf.in
@@ -8,7 +8,7 @@
 
     <joint name="fixed_base" type="fixed">
       <parent>world</parent>
-      <child>iCub::base_link</child>
+      <child>iCub::root_link</child>
     </joint>
   </model>
 </sdf>


### PR DESCRIPTION
This commit is required because of robotology/icub-model-generator#142

The PR fixes #58 