### PR TITLE
Tune the torso position PID for iCubGazeboV3

### DIFF
--- a/iCub/conf_icub3/gazebo_icub_torso.ini
+++ b/iCub/conf_icub3/gazebo_icub_torso.ini
@@ -37,9 +37,9 @@ max_damping   100.0  100.0  100.0
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            1.745 1.745 1.745
+kp            1.745 5.745 15.745
 kd            0.174 0.174 0.174
-ki            0.174 0.174 0.174
+ki            0.174 4.174 3.174
 maxInt        9999  9999  9999
 maxOutput     9999  9999  9999
 shift         0.0   0.0   0.0


### PR DESCRIPTION
With this choice of gains the tracking of the torso joint position performances increases 