### PR TITLE
Fix iCubV3 r_wrist_yaw joint

### DIFF
--- a/iCub/robots/iCubGazeboV3/model.urdf
+++ b/iCub/robots/iCubGazeboV3/model.urdf
@@ -1022,12 +1022,13 @@
       </geometry>
     </collision>
   </link>
-  <joint name="r_wrist_yaw" type="continuous">
+  <joint name="r_wrist_yaw" type="revolute">
     <origin xyz="-0.016300122874272734 0.006999390051091792 0" rpy="0 0 0"/>
     <axis xyz="-2.4949582807394525e-07 1.0000002733514362 -2.7942487010105877e-08"/>
     <parent link="r_wrist_1"/>
     <child link="r_hand"/>
-    <dynamics damping="0.1"/>
+    <limit effort="50000" lower="-0.2617993877991494" upper="0.6108652381980153" velocity="120.0"/>
+    <dynamics damping="2.0" friction="0.0"/>
   </joint>
   <link name="l_shoulder_1">
     <inertial>

--- a/iCub/robots/iCubGenova09/model.urdf
+++ b/iCub/robots/iCubGenova09/model.urdf
@@ -1022,12 +1022,13 @@
       </geometry>
     </collision>
   </link>
-  <joint name="r_wrist_yaw" type="continuous">
+  <joint name="r_wrist_yaw" type="revolute">
     <origin xyz="-0.016300122874272734 0.006999390051091792 0" rpy="0 0 0"/>
     <axis xyz="-2.4949582807394525e-07 1.0000002733514362 -2.7942487010105877e-08"/>
     <parent link="r_wrist_1"/>
     <child link="r_hand"/>
-    <dynamics damping="0.1"/>
+    <limit effort="50000" lower="-0.2617993877991494" upper="0.6108652381980153" velocity="120.0"/>
+    <dynamics damping="2.0" friction="0.0"/>
   </joint>
   <link name="l_shoulder_1">
     <inertial>


### PR DESCRIPTION
Following https://github.com/robotology/icub-models/issues/93, with this PR I am temporary fixing the `r_wrist_yaw` description for both `iCubGazeboV3` and `iCubGenova09` by:
- converting joint type from `continuous` to `revolute`
- adding joint limits from `l_wrist_yaw` (they should be the same limits since the yaw rotation axis in left and right hand are opposite
- adding `damping` and `friction` values used for all the other joints