### PR TITLE
new pid vals for torso in walking simulations

### DIFF
--- a/iCub/conf_icub3/gazebo_icub_torso.ini
+++ b/iCub/conf_icub3/gazebo_icub_torso.ini
@@ -37,9 +37,9 @@ max_damping   100.0  100.0  100.0
 [POSITION_CONTROL]
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
-kp            40.0  40.0  40.0
-kd            0.35  0.35  0.35
-ki            0.35  0.35  0.35
+kp            30.0  30.0  30.0
+kd            0.2  0.2  0.2
+ki            0.2  0.2  0.2
 maxInt        9999  9999  9999
 maxOutput     9999  9999  9999
 shift         0.0   0.0   0.0


### PR DESCRIPTION
With reference to [this issue](https://github.com/ami-iit/component_ergocub/issues/61#issuecomment-1036205093) concerning a long stable walking for iCubV3 in Gazebo, and after some trial and error, we have these values for the pidparams. 

Also see [this comment and corresponding PR](https://github.com/robotology/walking-controllers/pull/106#issuecomment-1036054924). 

With these values, the walking in simulation seems stable as suggested by this video

https://user-images.githubusercontent.com/36491318/153611904-bf032f3c-d5e1-448d-b308-7a63559ca0b3.MP4

and also the torso controlled in position in isolation seems to work fine (so no side effect) as suggested by this video

https://user-images.githubusercontent.com/36491318/153612063-983e3c8c-0e3f-419b-bc94-98014e6979ca.mp4

In case, these modifications as I understood only concern controlling the robot in simulation, and since HSP are trying to use the walking-controllers to test their navigation strategies, I opened this pr.