### PR TITLE
Update cmake_minimum_required to 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Authors: Silvio Traversaro
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8)
 
 project(icub-models
   VERSION 1.22.1)


### PR DESCRIPTION
The following feature introduced in https://github.com/robotology/icub-models/pull/131

https://github.com/robotology/icub-models/blob/c6948add03cacd9e84fdad74df87939efb43902c/cpp/CMakeLists.txt#L31

is available from CMake version 3.8 (see [here](https://cmake.org/cmake/help/v3.8/release/3.8.html#c-c)).

This PR to update the CMake required version accordingly.

cc @traversaro @GiulioRomualdi 