### PR TITLE
Document that the ABI and the API of the C++ helper library only changes at major releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ int main()
 }
 ```
 
+***Note: The ABI and the API of the C++ helper library has breaking changes only at major releases of the `icub-models` package.***
+
 ### Use the models from Python helper library
 In order to use these models in `python` application you can exploit the `icub-models` module.
 `icub-models` provides `python` bindings support thanks to `pybind11` library.  To compile the


### PR DESCRIPTION
It should not a problem to enforce this due to the limited number of methods in the C++ helper library, but it convenient to clearly state to simplify the conda-forge packaging, as in this way downstream libraries only need to be recompiled when a new major release is released.