### PR TITLE
Reorder python-related find_package calls

### DIFF
--- a/bindings/CMakeLists.txt
+++ b/bindings/CMakeLists.txt
@@ -4,9 +4,8 @@
 
 if(ICUB_MODELS_COMPILE_PYTHON_BINDINGS)
 
+    find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
     find_package(pybind11 REQUIRED)
-    find_package(Python3 COMPONENTS Interpreter REQUIRED)
-
 
     # define new line accordingly to the operating system
     if (WIN32)


### PR DESCRIPTION
`find_package(pybind11)` depending on the pybind11 version can use old variants of `FindPython`. By calling `find_package(Python3)` first we ensure that the recommended variant `FindPython3` is used.