### PR TITLE
Fix Python configuration if PYTHON_INSTDIR is a relative path

### DIFF
--- a/.github/workflows/cxx-ci.yml
+++ b/.github/workflows/cxx-ci.yml
@@ -33,7 +33,7 @@ jobs:
         # Workaround for https://github.com/conda-incubator/setup-miniconda/issues/186
         conda config --remove channels defaults
         # Compilation related dependencies
-        mamba install cmake compilers make ninja pkg-config
+        mamba install cmake compilers make ninja pkg-config python
 
     - name: Print used environment [Conda]
       shell: bash -l {0}
@@ -47,7 +47,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
+        cmake -GNinja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DICUB_MODELS_USES_PYTHON:BOOL=ON -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} ..
 
     - name: Configure [Conda/Windows]
       if: contains(matrix.os, 'windows')
@@ -55,7 +55,7 @@ jobs:
       run: |
         mkdir build
         cd build
-        cmake -G"Visual Studio 16 2019" -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
+        cmake -G"Visual Studio 16 2019" -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX}/Library  -DICUB_MODELS_USES_PYTHON:BOOL=ON -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ..
 
     - name: Build [Conda]
       shell: bash -l {0}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+## [1.23.2] - 2020-03-31
+
+* Fix CMake configuration if Python library installation is enabled (https://github.com/robotology/icub-models/pull/146).
+
 ## [1.23.1] - 2022-03-30
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.8)
 
 project(icub-models
-  VERSION 1.23.1)
+  VERSION 1.23.2)
 
 include(GNUInstallDirs)
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -27,8 +27,13 @@ if(ICUB_MODELS_USES_PYTHON)
             DESTINATION ${PYTHON_INSTDIR})
 
     # Install the icub_models.py file inserting the relative path between
-    # ${PYTHON_INSTDIR} and ${CMAKE_INSTALL_DIR}
-    file(RELATIVE_PATH ICUB_MODELS_CXX_PYTHON_INSTALL_RELATIVE_DIR ${PYTHON_INSTDIR} ${CMAKE_INSTALL_PREFIX})
+    # ${PYTHON_ABSOLUTE_INSTDIR} and ${CMAKE_INSTALL_DIR}
+    if(IS_ABSOLUTE ${PYTHON_INSTDIR})
+      set(PYTHON_ABSOLUTE_INSTDIR "${PYTHON_INSTDIR}")
+    else()
+      set(PYTHON_ABSOLUTE_INSTDIR "${CMAKE_INSTALL_DIR}/${PYTHON_INSTDIR}")
+    endif()
+    file(RELATIVE_PATH ICUB_MODELS_CXX_PYTHON_INSTALL_RELATIVE_DIR ${PYTHON_ABSOLUTE_INSTDIR} ${CMAKE_INSTALL_PREFIX})
     configure_file("${CMAKE_CURRENT_SOURCE_DIR}/icub_models/icub_models.py"
                    "${CMAKE_CURRENT_BINARY_DIR}/icub_models/icub_models.py"
                     @ONLY)


### PR DESCRIPTION
Fix https://github.com/robotology/robotology-superbuild/issues/1076 .

Furthermore, enable the installation of Python bindings in CMake CI job to avoid these kind of regressions.