### PR TITLE
Fix get_models_path() when the icub_models package is installed with the superbuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+### Fixed 
+* In Python helper library, fix the get_models_path() when the `icub_models` package is installed with the robotology-superbuild (https://github.com/robotology/icub-models/pull/149).
+
 ## [1.23.2] - 2020-03-31
+
+### Fixed
 
 * Fix CMake configuration if Python library installation is enabled (https://github.com/robotology/icub-models/pull/146).
 

--- a/python/icub_models/icub_models.py
+++ b/python/icub_models/icub_models.py
@@ -20,7 +20,7 @@ def get_models_path() -> pathlib.Path:
         else:
             root = pathlib.Path(__file__).parent.parent.parent.parent.parent
     else:
-        root = pathlib.Path(__file__) / relative_path
+        root = pathlib.Path(__file__) / pathlib.Path(relative_path)
 
     return (root / "share" / "iCub" / "robots").resolve()
 


### PR DESCRIPTION
cc @Nicogene 

This fixes #148 