### PR TITLE
Drop trailing \0 characters in value returned by iCubModels::getModelsPath function and release 1.23.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
-# Copyright: (C) 2017 Fondazione Istituto Italiano di Tecnologia
+# Copyright: (C) 2022 Fondazione Istituto Italiano di Tecnologia
 # Authors: Silvio Traversaro
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
 cmake_minimum_required(VERSION 3.8)
 
 project(icub-models
-  VERSION 1.23.3)
+  VERSION 1.23.4)
 
 include(GNUInstallDirs)
 

--- a/cpp/src/iCubModels.cpp.in
+++ b/cpp/src/iCubModels.cpp.in
@@ -12,6 +12,11 @@ namespace iCubModels
 std::string getModelsPath()
 {
     std::string retstr = "@ICUB_MODELS_MODELS_PATH@";
+    // Sometimes the relocation of the C++ library in conda or similar systems is not working correctly
+    // and is leaving at the end of the retstr many \0 characters. To be sure not to return a faulty
+    // string, we remove all the trailing \0
+    // See https://github.com/ami-iit/bipedal-locomotion-framework/pull/526
+    retstr.erase(std::find(retstr.begin(), retstr.end(), '\0'), retstr.end());
     return retstr;
 }
 

--- a/cpp/src/iCubModels.cpp.in
+++ b/cpp/src/iCubModels.cpp.in
@@ -37,7 +37,7 @@ std::string getModelFile(const std::string& modelName)
         return modelFile;
     }
 
-    modelFile = "@ICUB_MODELS_MODELS_PATH@/" + modelName + "/model.urdf";
+    modelFile = getModelsPath() +  "/" + modelName + "/model.urdf";
     return modelFile;
 }
 } // namespace iCubModels

--- a/cpp/src/iCubModels.cpp.in
+++ b/cpp/src/iCubModels.cpp.in
@@ -7,6 +7,8 @@
 
 #include <iCubModels/iCubModels.h>
 
+#include <algorithm>
+
 namespace iCubModels
 {
 std::string getModelsPath()


### PR DESCRIPTION
This should make the library more robust to problems in relocation in conda or similar systems, see for example:
* https://github.com/ami-iit/bipedal-locomotion-framework/pull/526
* https://github.com/conda-forge/libignition-gazebo-feedstock/issues/4
* https://github.com/conda-forge/libignition-rendering4-feedstock/issues/25
* https://github.com/conda/conda-build/issues/1674
* https://github.com/conda/conda-build/issues/2524