### PR TITLE
Move CI jobs from soon to be removed macos-10.15 to macos-latest

### DIFF
--- a/.github/workflows/cxx-ci.yml
+++ b/.github/workflows/cxx-ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-latest, windows-2019]
 
     steps:
     - uses: actions/checkout@v2
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-18.04, ubuntu-20.04, macOS-10.15]
+        os: [ubuntu-18.04, ubuntu-latest, macOS-10.15]
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/cxx-ci.yml
+++ b/.github/workflows/cxx-ci.yml
@@ -70,7 +70,7 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [Release]
-        os: [ubuntu-18.04, ubuntu-latest, macOS-10.15]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest]
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/pip-ci.yml
+++ b/.github/workflows/pip-ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', 'pypy-3.8']
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-latest, windows-2019]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
`macos-10.15` will be removed soon, see https://github.com/actions/virtual-environments/issues/5583 . 
For this reason we move CI jobs to `macos-latest`. Note that in the past for macos we used fixed release images (i.e. `macos-10.15` instead of `macos-latest`) to reduce the mantainance burden, but as these images are frequently deprecated/removed, perhaps using `-latest` should actually reduce the mantainance burden.