### PR TITLE
Do not use homebrew on Linux

### DIFF
--- a/.github/workflows/cxx-ci.yml
+++ b/.github/workflows/cxx-ci.yml
@@ -85,6 +85,7 @@ jobs:
     # ============
 
     - name: Dependencies [macOS]
+      if: contains(matrix.os, 'macos')
       run: |
         brew install cmake
 


### PR DESCRIPTION
The "Dependencies [macOS]" step was running also on Linux, and was working fine I guess because `brew` was also installed on Linux, but it started failing on 2022/09/27 probably as something in the Linux GitHub Actions image changed.

Fix https://github.com/robotology/icub-models/issues/172 .