### PR TITLE
Fix regression in PR #186

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 macro(SUBDIRLIST result curdir)
+  file(GLOB children RELATIVE ${curdir} ${curdir}/*)
   set(dirlist "")
   foreach(child ${children})
     if(IS_DIRECTORY ${curdir}/${child})


### PR DESCRIPTION
Fix https://github.com/robotology/icub-models/issues/189 . In https://github.com/robotology/icub-models/pull/186 there was a wrong removal of a line in the `macro(SUBDIRLIST result curdir)`.