### PR TITLE
Release icub-models v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+# [2.0.0] - 2023-03-08
+
+### Fixed
+
+* Make models compatible with the YARP 3.8 (https://github.com/robotology/icub-models/issues/171, https://github.com/robotology/icub-models/pull/188, https://github.com/robotology/icub-models-generator/pull/231).
+* Fix incompatibility between RViz2 and iCubGazeboV3 model ( https://github.com/robotology/icub-models-generator/issues/229 ).
+* Uniform IMUs sensor names (https://github.com/robotology/icub-models-generator/pull/235).
+* Add partial support to expose sensor data of iCubGazeboV3 on ROS2 (https://github.com/robotology/icub-models-generator/pull/228).
+
+
 # [1.26.0] - 2022-12-09
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.8)
 
 project(icub-models
-  VERSION 1.26.0)
+  VERSION 2.0.0)
 
 include(GNUInstallDirs)
 

--- a/iCub_manual/package.xml
+++ b/iCub_manual/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>iCub</name>
-  <version>1.26.0</version>
+  <version>2.0.0</version>
   <description>
     This is not an actual package, but rather a placeholder to 
     make sure that the share/iCub directory is found as the 


### PR DESCRIPTION
Reason to bump to v2.0.0 : 
* All the visually similar but different v1.* versions for icub-* was quite confusing to me
* Migrate to use `gazebo_yarp_robotinterface` 