### PR TITLE
Make iCubGazeboV_2_5_visuomanip RGB camera port names harmonized again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format of this document is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
+* Harmonize iCubGazeboV2_5_visuomanip RGB cameras port name (https://github.com/robotology/icub-models/pull/196)
 
 # [1.26.0] - 2022-12-09
 

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/wrappers/camera/right_camera-rgb_wrapper.xml
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/wrappers/camera/right_camera-rgb_wrapper.xml
@@ -3,7 +3,7 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_camera_rgb_nws_yarp" type="frameGrabber_nws_yarp">
     <param name="period">0.033</param>
-    <param name="name"> ${portprefix}/cam/right </param>
+    <param name="name"> ${portprefix}/cam/right/rgbImage:o </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">
             <elem name="the_device"> icub_right_camera_rgb </elem>


### PR DESCRIPTION
As per the title, this restore port names for the RGB cameras of `iCubGazeboV_2_5_visuomanip` such that they are as in 

https://github.com/robotology/icub-models/pull/45/files#diff-1e5c2f03288ab12a5b18118bc44ed0d0096511a21c7c2e02fe851c185e3de101

and not as in 

https://github.com/robotology/icub-models/pull/188/files#diff-e4397ef8e3fdcf273315c11bd778759f2352f511dbf53babc3c7b2b8284fa491

where the right camera port name was changed to `/icubSim/cam/right` by mistake.

With this change, the port names associated to the cameras are:

```console
registration name /icubSim/cam/left/depthImage:o
registration name /icubSim/cam/left/rgbImage:o
registration name /icubSim/cam/left/rpc:i
registration name /icubSim/cam/right/rgbImage:o
registration name /icubSim/cam/right/rgbImage:o/rpc
```
i.e., different from the real robot, as documented in #47, but at least harmonized.

Fixes #195 

cc @traversaro @pattacini @davidegorbani 