### PR TITLE
Support iCubGazebo2_6 and iCubGazebo2_7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ set(ICUB_MODELS_SDF_VERSION "1.7")
 set(GAZEBO_SUPPORTED_MODELS "")
 list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV2_5")
 list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV2_5_plus")
+list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV2_6")
+list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV2_7")
 list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV3")
 
 # Note: these models don't need further configuration apart from


### PR DESCRIPTION
It'd be nice to support these two robots in Gazebo.
As of now, `model.config` doesn't get installed indeed.