### PR TITLE
Support joints publishing on ROS 2 for iCubGazeboV2_5_visuomanip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ## [Unreleased]
 
+### Changed
+* Enable publishing of robot joints in ROS 2 via `controlBoard_nws_ros2` for `iCubGazeboV2_5_visuomanip` (https://github.com/robotology/icub-models/pull/211).
+
 # [2.3.0] - 2023-09-11
 
 ### Fixed

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/icub_ros2.xml
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/icub_ros2.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<robot name="iCubGazeboV3" build="1" portprefix="/icubSim" xmlns:xi="http://www.w3.org/2001/XInclude">
+    <devices>
+
+    <!-- MOTOR CONTROLLERS -->
+
+        <!-- wrapper are all inherited from automatically generated models -->
+        <xi:include href="../../../iCub/conf/wrappers/motorControl/torso-mc_wrapper.xml" />
+        <xi:include href="../../../iCub/conf/wrappers/motorControl/head-mc_wrapper.xml" />
+        <xi:include href="../../../iCub/conf/wrappers/motorControl/left_arm-mc_wrapper.xml" />
+        <xi:include href="../../../iCub/conf/wrappers/motorControl/right_arm-mc_wrapper.xml" />
+
+        <!-- only the torso remapper is inherited from automatically generated models -->
+        <xi:include href="../../../iCub/conf/wrappers/motorControl/torso-mc_remapper.xml" />
+
+        <!-- all the other remappers are specific to this model due to eyes and fingers -->
+        <xi:include href="wrappers/motorControl/head-mc_remapper.xml" />
+        <xi:include href="wrappers/motorControl/left_arm-mc_remapper.xml" />
+        <xi:include href="wrappers/motorControl/right_arm-mc_remapper.xml" />
+    <!-- -->
+
+    <!-- HEAD SENSORS -->
+
+        <xi:include href="wrappers/camera/left_camera-rgbd_wrapper.xml" />
+        <xi:include href="wrappers/camera/right_camera-rgb_wrapper.xml" />
+
+    <!-- -->
+
+    <!-- INERTIAL SENSORS -->
+
+        <!-- this wrapper is inherited from automatically generated models -->
+        <xi:include href="../../../iCub/conf/wrappers/inertials/head-inertials_wrapper.xml" />
+
+    <!-- -->
+
+    <!-- ROS 2 entries -->
+    <xi:include href="wrappers/motorControl/alljoints-mc_remapper.xml" />
+    <xi:include href="wrappers/motorControl/alljoints-mc_nws_ros2.xml" />
+
+    </devices>
+</robot>

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/wrappers/motorControl/alljoints-mc_nws_ros2.xml
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/wrappers/motorControl/alljoints-mc_nws_ros2.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-mc_nws_ros2" type="controlBoard_nws_ros2">
+    <param name="node_name"> icub_cb_node </param>
+    <param name="topic_name"> /joint_states </param>
+    <action phase="startup" level="10" type="attach">
+        <param name="device"> alljoints-mc_remapper </param>
+    </action>
+    <action phase="shutdown" level="15" type="detach" />
+</device>

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/wrappers/motorControl/alljoints-mc_remapper.xml
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/wrappers/motorControl/alljoints-mc_remapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="alljoints-mc_remapper" type="controlboardremapper">
+    <param name="axesNames">(neck_pitch neck_roll neck_yaw l_shoulder_pitch l_shoulder_roll l_shoulder_yaw l_elbow l_wrist_prosup l_wrist_pitch l_wrist_yaw r_shoulder_pitch r_shoulder_roll r_shoulder_yaw r_elbow r_wrist_prosup r_wrist_pitch r_wrist_yaw torso_yaw torso_roll torso_pitch)</param>
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="head_joints">       head_hardware_device </elem>
+            <elem name="left_arm_joints">   left_arm_hardware_device</elem>
+            <elem name="right_arm_joints">  right_arm_hardware_device </elem>
+            <elem name="torso_joints">      torso_hardware_device </elem>
+        </paramlist>
+    </action>
+    <action phase="shutdown" level="20" type="detach"/>
+</device>


### PR DESCRIPTION
As per the title.

It adds an `icub_ros2.xml`, mimicking [that](https://github.com/robotology/robots-configuration/blob/master/iCubGenova11/icub_all_no_legs_ros2.xml) of `iCubGenova11` which, similary to `iCubGazeboV2_5_visuomanip`, does not have legs enabled.

Using this file, instead of `icub.xml`, in

https://github.com/robotology/icub-models/blob/9f5e04bbb0c119bb045db88ee333ac55d616cd92/iCub_manual/robots/iCubGazeboV2_5_visuomanip/model.urdf#L2753

a standard ROS2-based robot state publisher can be executed.

Notes:
- unfortunately, `icub_ros2.xml` cannot be made the default as it is not granted that each user of `icub-models` is also using `yarp-ros2-devices`.

- fingers and eyes are not exposed as, at the moment, the robot state publisher would not know how to extract the physical joint from the coupled ones. I can add them in the future once the development in https://github.com/robotology/yarp/pull/3026 is completed.

cc @traversaro 