### PR TITLE
Bump policy_max argument of cmake_minimum_required to 3.16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-# Copyright: (C) 2022 Fondazione Istituto Italiano di Tecnologia
+# Copyright: (C) Fondazione Istituto Italiano di Tecnologia
 # Authors: Silvio Traversaro
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later, see LGPL.TXT
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.16)
 
 project(icub-models
   VERSION 2.3.0)


### PR DESCRIPTION
This is to ensure that https://cmake.org/cmake/help/latest/policy/CMP0094.html#policy:CMP0094 is set to `NEW`, to ensure that the Python present in the conda environment is found even if in the system another (newer) Python is found.

Fix https://github.com/robotology/icub-models/issues/216 .
Similar to https://github.com/robotology/robotology-superbuild/pull/1506 .