### PR TITLE
CMake: Permit to explictly specify Python installation directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format of this document is based on [Keep a Changelog](https://keepachangelo
 
 ### Changed
 * Enable publishing of robot joints in ROS 2 via `controlBoard_nws_ros2` for `iCubGazeboV2_5_visuomanip` (https://github.com/robotology/icub-models/pull/211).
+* CMake: Permit to explictly specify Python installation directory by setting the `ICUB_MODELS_PYTHON_INSTALL_DIR` CMake variable (https://github.com/robotology/icub-models/pull/218).
 
 ### Fixed
 * Fixed wrong simulated finger hall effect sensors port names prefix for `iCubGazeboV2_5_visuomanip` (https://github.com/robotology/icub-models/pull/215).

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -11,15 +11,18 @@ if(ICUB_MODELS_USES_PYTHON)
     FALSE)
 
     # Install the resulting Python package for the active interpreter
-    if(ICUB_MODELS_DETECT_ACTIVE_PYTHON_SITEPACKAGES)
-        set(PYTHON_INSTDIR ${Python3_SITELIB}/icub_models)
-    else()
-      execute_process(COMMAND ${Python3_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
-        OUTPUT_VARIABLE _PYTHON_INSTDIR)
-
-      string(STRIP ${_PYTHON_INSTDIR} _PYTHON_INSTDIR_CLEAN)
-      set(PYTHON_INSTDIR ${_PYTHON_INSTDIR_CLEAN}/icub_models)
+    if(NOT DEFINED ICUB_MODELS_PYTHON_INSTALL_DIR)
+      if(ICUB_MODELS_DETECT_ACTIVE_PYTHON_SITEPACKAGES)
+        set(ICUB_MODELS_PYTHON_INSTALL_DIR ${Python3_SITELIB})
+      else()
+        execute_process(COMMAND ${Python3_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
+          OUTPUT_VARIABLE _PYTHON_INSTDIR)
+        string(STRIP ${_PYTHON_INSTDIR} _PYTHON_INSTDIR_CLEAN)
+        set(ICUB_MODELS_PYTHON_INSTALL_DIR ${_PYTHON_INSTDIR_CLEAN})
+      endif()
     endif()
+    set(PYTHON_INSTDIR ${ICUB_MODELS_PYTHON_INSTALL_DIR}/icub_models)
+
 
 
     # Install the __init__.py file


### PR DESCRIPTION
This is done by setting the ICUB_MODELS_PYTHON_INSTALL_DIR CMake variable.