### PR TITLE
Fix code to obtain Python relative install dir in Python 3.12

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -14,8 +14,13 @@ if(ICUB_MODELS_USES_PYTHON)
     if(ICUB_MODELS_DETECT_ACTIVE_PYTHON_SITEPACKAGES)
         set(PYTHON_INSTDIR ${Python3_SITELIB}/icub_models)
     else()
-      execute_process(COMMAND ${Python3_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
-        OUTPUT_VARIABLE _PYTHON_INSTDIR)
+      if(Python3_VERSION VERSION_GREATER_EQUAL 3.12)
+        execute_process(COMMAND ${Python3_EXECUTABLE} -c "import os;import sysconfig;relative_site_packages = sysconfig.get_path('purelib').replace(sysconfig.get_path('data'), '').lstrip(os.path.sep);print(relative_site_packages)"
+          OUTPUT_VARIABLE _PYTHON_INSTDIR)
+      else()
+        execute_process(COMMAND ${Python3_EXECUTABLE} -c "from distutils import sysconfig; print(sysconfig.get_python_lib(1,0,prefix=''))"
+          OUTPUT_VARIABLE _PYTHON_INSTDIR)
+      endif()
 
       string(STRIP ${_PYTHON_INSTDIR} _PYTHON_INSTDIR_CLEAN)
       set(PYTHON_INSTDIR ${_PYTHON_INSTDIR_CLEAN}/icub_models)


### PR DESCRIPTION
As the code in some cases return slightly different results then the previous version (see #1238 (comment)), we only use it when Python >= 3.12 .