### PR TITLE
iCubGazeboV2_5_visuomanip: migrate hand encoder arrays (i.e. MAIS) sensors to use multipleanalogsensorsserver and gazebo_yarp_robotinterface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.8...3.16)
 
 project(icub-models
-  VERSION 2.7.0)
+  VERSION 2.8.0)
 
 include(GNUInstallDirs)
 

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_left_hand_mais.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_left_hand_mais.ini
@@ -1,8 +1,4 @@
-[WRAPPER]
-name /icubSim/left_hand/analog:o
-period 10
-networks (left_mais)
-device analogServer
-
-[left_mais]
+disableImplicitNetworkWrapper
+yarpDeviceName icub_left_hand_mais_hardware_device
+sensorName l_hand_mais
 jointNames l_hand_thumb_1_joint l_hand_thumb_2_joint l_hand_thumb_3_joint l_hand_index_1_joint l_hand_index_2_joint l_hand_index_3_joint l_hand_middle_1_joint l_hand_middle_2_joint l_hand_middle_3_joint l_hand_ring_1_joint l_hand_ring_2_joint l_hand_ring_3_joint l_hand_little_1_joint l_hand_little_2_joint l_hand_little_3_joint

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_right_hand_mais.ini
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/gazebo_icub_right_hand_mais.ini
@@ -1,8 +1,4 @@
-[WRAPPER]
-name /icubSim/right_hand/analog:o
-period 10
-networks (right_mais)
-device analogServer
-
-[right_mais]
+disableImplicitNetworkWrapper
+yarpDeviceName icub_right_hand_mais_hardware_device
+sensorName r_hand_mais
 jointNames r_hand_thumb_1_joint r_hand_thumb_2_joint r_hand_thumb_3_joint r_hand_index_1_joint r_hand_index_2_joint r_hand_index_3_joint r_hand_middle_1_joint r_hand_middle_2_joint r_hand_middle_3_joint r_hand_ring_1_joint r_hand_ring_2_joint r_hand_ring_3_joint r_hand_little_1_joint r_hand_little_2_joint r_hand_little_3_joint

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/icub.xml
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/icub.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-<robot name="iCubGazeboV3" build="1" portprefix="/icubSim" xmlns:xi="http://www.w3.org/2001/XInclude">
+<robot name="iCubGazeboV2_5" build="1" portprefix="/icubSim" xmlns:xi="http://www.w3.org/2001/XInclude">
     <devices>
 
     <!-- MOTOR CONTROLLERS -->
@@ -34,6 +34,14 @@
         <xi:include href="../../../iCub/conf/wrappers/inertials/head-inertials_wrapper.xml" />
 
     <!-- -->
+
+    <!-- MAIS (i.e. ENCODER ARRAY) SENSORS -->
+
+        <xi:include href="wrappers/MAIS/left_arm-mais_wrapper.xml" />
+        <xi:include href="wrappers/MAIS/right_arm-mais_wrapper.xml" />
+
+    <!-- -->
+
 
     </devices>
 </robot>

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/icub_ros2.xml
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/icub_ros2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE robot PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
 
-<robot name="iCubGazeboV3" build="1" portprefix="/icubSim" xmlns:xi="http://www.w3.org/2001/XInclude">
+<robot name="iCubGazeboV2_5" build="1" portprefix="/icubSim" xmlns:xi="http://www.w3.org/2001/XInclude">
     <devices>
 
     <!-- MOTOR CONTROLLERS -->
@@ -32,6 +32,13 @@
 
         <!-- this wrapper is inherited from automatically generated models -->
         <xi:include href="../../../iCub/conf/wrappers/inertials/head-inertials_wrapper.xml" />
+
+    <!-- -->
+
+    <!-- MAIS (i.e. ENCODER ARRAY) SENSORS -->
+
+        <xi:include href="wrappers/MAIS/left_arm-mais_wrapper.xml" />
+        <xi:include href="wrappers/MAIS/right_arm-mais_wrapper.xml" />
 
     <!-- -->
 

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -3,7 +3,8 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
     <param name="period">       10                         </param>
-    <param name="name">       /icub/left_hand/MAIS      </param>
+    <param name="name">       /icubSim/left_hand/MAIS      </param>
+
         
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/wrappers/MAIS/left_arm-mais_wrapper.xml
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/wrappers/MAIS/left_arm-mais_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="left_arm-mais_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">       10                         </param>
+    <param name="name">       /icub/left_hand/MAIS      </param>
+        
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="leftMais"> icub_left_hand_mais_hardware_device </elem>
+        </paramlist>
+    </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE devices PUBLIC "-//YARP//DTD yarprobotinterface 3.0//EN" "http://www.yarp.it/DTD/yarprobotinterfaceV3.0.dtd">
+
+<device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
+    <param name="period">       10                         </param>
+    <param name="name">       /icub/right_hand/MAIS      </param>
+        
+    <action phase="startup" level="5" type="attach">
+        <paramlist name="networks">
+            <elem name="rightMais"> icub_right_hand_mais_hardware_device </elem>
+        </paramlist>
+    </action>
+
+    <action phase="shutdown" level="20" type="detach" />
+</device>

--- a/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/wrappers/MAIS/right_arm-mais_wrapper.xml
+++ b/iCub_manual/conf_manual/iCubGazeboV2_5_visuomanip/wrappers/MAIS/right_arm-mais_wrapper.xml
@@ -3,7 +3,8 @@
 
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="right_arm-mais_wrapper" type="multipleanalogsensorsserver">
     <param name="period">       10                         </param>
-    <param name="name">       /icub/right_hand/MAIS      </param>
+    <param name="name">       /icubSim/right_hand/MAIS      </param>
+
         
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">

--- a/iCub_manual/package.xml
+++ b/iCub_manual/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>iCub</name>
-  <version>2.7.0</version>
+  <version>2.8.0</version>
   <description>
     This is not an actual package, but rather a placeholder to 
     make sure that the share/iCub directory is found as the 


### PR DESCRIPTION
Fix https://github.com/robotology/icub-models/issues/234, and in particular align the simulated robot with the real robot. The chosen sensor names are `l_arm_mais` and `r_arm_mais`, as the existing names in the robot are broken (see https://github.com/robotology/robots-configuration/issues/679).

Furthermore, this migrates the mais sensor to use both `multipleanalogsensorsserver` and `gazebo_yarp_robotinterface`.

Note: this PR requires https://github.com/robotology/gazebo-yarp-plugins/pull/688 to be merged before.