### PR TITLE
icub-models python library: Raise a `FileNotFoundError` if the model path is not found

### DIFF
--- a/.github/workflows/cxx-ci.yml
+++ b/.github/workflows/cxx-ci.yml
@@ -23,7 +23,6 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        miniforge-variant: Mambaforge
         miniforge-version: latest
         channels: conda-forge
 
@@ -34,12 +33,12 @@ jobs:
         conda config --remove channels defaults
         # Build and test dependencies (ROS packages to test that resouces are find correctly by ROS/ROS2)
         # ros-noetic-catkin is required otherwised ROS_PACKAGE_PATH is not defined and rospack list does not return anything
-        mamba install -c conda-forge -c robostack -c robostack-humble cmake compilers make ninja pkg-config python ros-noetic-rospack ros-noetic-catkin ros-humble-ros2pkg
+        conda install -c conda-forge -c robostack -c robostack-humble cmake compilers make ninja pkg-config python ros-noetic-rospack ros-noetic-catkin ros-humble-ros2pkg
 
     - name: Print used environment [Conda]
       shell: bash -l {0}
       run: |
-        mamba list
+        conda list
         env
 
     - name: Configure [Conda/Linux&macOS]

--- a/.github/workflows/cxx-ci.yml
+++ b/.github/workflows/cxx-ci.yml
@@ -19,9 +19,9 @@ jobs:
         os: [ubuntu-20.04, macos-latest, windows-2019]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         miniforge-variant: Mambaforge
         miniforge-version: latest
@@ -103,8 +103,8 @@ jobs:
       image: ${{ matrix.docker_image }}
 
     steps:
-    - uses: actions/checkout@v3
- 
+    - uses: actions/checkout@v4
+
     # Print environment variables to simplify development and debugging
     - name: Environment Variables
       shell: bash
@@ -125,7 +125,7 @@ jobs:
         mkdir -p build
         cd build
         cmake -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install ..
-        
+
     - name: Build
       shell: bash
       run: |

--- a/.github/workflows/pip-ci.yml
+++ b/.github/workflows/pip-ci.yml
@@ -19,10 +19,10 @@ jobs:
         os: [ubuntu-20.04, macos-latest, windows-2019]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pypi-ci.yml
+++ b/.github/workflows/pypi-ci.yml
@@ -25,11 +25,11 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -40,7 +40,7 @@ jobs:
         run: python -m build --sdist --wheel --outdir dist/ .
 
       - name: Archive artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
@@ -53,13 +53,13 @@ jobs:
     steps:
 
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
 
       - name: Publish distribution 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
@@ -72,12 +72,12 @@ jobs:
     steps:
 
       - name: Download artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
 
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/trigger_bru.yml
+++ b/.github/workflows/trigger_bru.yml
@@ -57,7 +57,7 @@ jobs:
           repository: robotology/blender-robotics-utils
 
       - name: Repository dispatch to blender-robotics-utils
-        uses: peter-evans/repository-dispatch@v1
+        uses: peter-evans/repository-dispatch@v3
         if:  steps.set_model_list.outputs.models != ''
         env:
           GITHUB_APPS_TOKEN: ${{ steps.get_workflow_token.outputs.token }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.8...3.16)
 
 project(icub-models
-  VERSION 2.8.0)
+  VERSION 2.8.1)
 
 include(GNUInstallDirs)
 

--- a/iCub_manual/package.xml
+++ b/iCub_manual/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>iCub</name>
-  <version>2.8.0</version>
+  <version>2.8.1</version>
   <description>
     This is not an actual package, but rather a placeholder to 
     make sure that the share/iCub directory is found as the 

--- a/python/icub_models/icub_models.py
+++ b/python/icub_models/icub_models.py
@@ -35,4 +35,4 @@ def get_model_file(robot_name: str) -> pathlib.Path:
     if model_file.is_file():
         return model_file
     else:
-        return pathlib.Path("...")
+        raise FileNotFoundError(f"Model file for robot {robot_name} not found.")


### PR DESCRIPTION
Instead of returning a placeholder `Path("...")` from https://github.com/robotology/icub-models/blob/468b9f7d033411dc138b877d4e229a4739ea083c/python/icub_models/icub_models.py#L32-L38 when the model name is not found I think it is more predictable and safe to raise an exception here.