### PR TITLE
Fix minor URL typo in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ author = Giulio Romualdi
 author_email = giulio.romualdi@gmail.com
 license = Creative Commons Attribution Share Alike 4.0 International
 license_file = LICENSE
-url = https://github.com/robotolgy/icub-models
+url = https://github.com/robotology/icub-models
 platforms = any
 
 project_urls =


### PR DESCRIPTION
This PR fixes a minor typo that made the Homepage URL unreachable from https://pypi.org/project/icub-models/