### PR TITLE
Bump version to 3.0.0 and follow up in removal iCub3 files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,6 @@ list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV2_5")
 list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV2_5_plus")
 list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV2_6")
 list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV2_7")
-list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV3")
 
 # Note: these models don't need further configuration apart from
 # model version in model.config. Only one configuration is generated for
@@ -148,7 +147,7 @@ endforeach()
 
 # Deal with manually generated models
 set(GAZEBO_SUPPORTED_MODELS "")
-list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV2_5_visuomanip" "iCubGazeboV3_visuomanip")
+list(APPEND GAZEBO_SUPPORTED_MODELS "iCubGazeboV2_5_visuomanip")
 
 SUBDIRLIST(ROBOTS_NAMES ${CMAKE_CURRENT_SOURCE_DIR}/iCub_manual/robots)
 foreach(ROBOT_NAME ${ROBOTS_NAMES})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.8...3.16)
 
 project(icub-models
-  VERSION 2.8.1)
+  VERSION 3.0.0)
 
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ The models contained in `icub-models` are listed in the following table. Most mo
 | `iCubGazeboV2_5_KIT_007`| `package://iCub/robots/iCubGazeboV2_5_KIT_007/model.urdf` | v2.5 + [KIT_007](https://icub-tech-iit.github.io/documentation/upgrade_kits/ankle_for_stairs/support/) with backpack, joint damping, and inertias of some links increased in a non realistic way to run smoothly in Gazebo Classic (ODE). |
 | `iCubGazeboV2_6`     | `package://iCub/robots/iCubGazeboV2_6/model.urdf` | v2.6 with  joint damping, and inertias of some links increased in a non realistic way to run smoothly in Gazebo Classic (ODE). |
 | `iCubGazeboV2_7`     | `package://iCub/robots/iCubGazeboV2_7/model.urdf` | v2.7 with  joint damping, and inertias of some links increased in a non realistic way to run smoothly in Gazebo Classic (ODE). |
-| `iCubGazeboV3`       | `package://iCub/robots/iCubGazeboV3/model.urdf` | v3 with  joint damping, and inertias of some links increased in a non realistic way to run smoothly in Gazebo Classic (ODE). |
-| `iCubGazeboV3_visuomanip` | `package://iCub/robots/iCubGazeboV3_visuomanip/model.urdf`  | v3 with hands and eyes |
 | `iCubGenova02`       | `package://iCub/robots/iCubGenova02/model.urdf` | v2.5.5 + [KIT_007](https://icub-tech-iit.github.io/documentation/upgrade_kits/ankle_for_stairs/support/) with backpack           |
 | `iCubGenova03`       | `package://iCub/robots/iCubGenova03/model.urdf`           | v2 with legs v1 and feet v2.5   |
 | `iCubGenova11`       | `package://iCub/robots/iCubGenova11/model.urdf`           | v2.7   |

--- a/iCub_manual/package.xml
+++ b/iCub_manual/package.xml
@@ -1,6 +1,6 @@
 <package>
   <name>iCub</name>
-  <version>2.8.1</version>
+  <version>3.0.0</version>
   <description>
     This is not an actual package, but rather a placeholder to 
     make sure that the share/iCub directory is found as the 

--- a/iCub_manual/ros2/README.md
+++ b/iCub_manual/ros2/README.md
@@ -13,7 +13,7 @@ Right now are published on ROS2 topics:
 
 The steps to run rviz visualization correctly are:
 
-- Edit `iCubGazeboV*/model.urdf` putting  [`icub_ROS2.xml`](https://github.com/robotology/robots-configuration/blob/devel/iCub/conf_icub3/wrappers/icub_ROS2.xml) `robotinterface` xml file used at startup.
+- Edit `iCubGazeboV*/model.urdf` putting  `icub_ros2.xml` `robotinterface` xml file used at startup.
 - Ensure that the robot is started correctly with ros configuration files for motor control boards.
 - On starting the robot, one should see `/<prefix>/joint_states` ros topic by running `ros2 topic list`.
   Also, ensure that the `/<prefix>/joint_states` streams all the robot joint angles by running

--- a/iCub_manual/ros2/README.md
+++ b/iCub_manual/ros2/README.md
@@ -1,6 +1,6 @@
 :warning: The ROS2 support is in beta :warning:
 
-This directory contains the files related for using `iCubGazeboV3` with ROS2. The contents of this directory are installed inside `iCub`.
+This directory contains the files related for using `iCubGazeboV*` with ROS2. The contents of this directory are installed inside `iCub`.
 ros2 package. The location of `iCub` ros pacakge is discovered by running `roscd iCub`.
 The `launch` directory contains `launch.py` file `robot_state_publisher.launch.py`. The robot model
 that will be used depends `YARP_ROBOT_NAME` set in `.bashrc`.
@@ -13,7 +13,7 @@ Right now are published on ROS2 topics:
 
 The steps to run rviz visualization correctly are:
 
-- Edit `iCubGazeboV3/model.urdf` putting  [`icub_ROS2.xml`](https://github.com/robotology/robots-configuration/blob/devel/iCub/conf_icub3/wrappers/icub_ROS2.xml) `robotinterface` xml file used at startup.
+- Edit `iCubGazeboV*/model.urdf` putting  [`icub_ROS2.xml`](https://github.com/robotology/robots-configuration/blob/devel/iCub/conf_icub3/wrappers/icub_ROS2.xml) `robotinterface` xml file used at startup.
 - Ensure that the robot is started correctly with ros configuration files for motor control boards.
 - On starting the robot, one should see `/<prefix>/joint_states` ros topic by running `ros2 topic list`.
   Also, ensure that the `/<prefix>/joint_states` streams all the robot joint angles by running


### PR DESCRIPTION
As we removed iCub 3 I think it make sense to bump the major version. 

I also did a bit of follow up on https://github.com/robotology/icub-models/pull/243 . @Nicogene can you also check the `ros2` directory? It seems that it contains iCub3-related stuff, I wonder if we can remove it. It seems it was added in https://github.com/robotology/icub-models/pull/184 .